### PR TITLE
Fixing npm's `high severity vulnerability`.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2265,9 +2265,9 @@
 			"dev": true
 		},
 		"handlebars": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.2.0.tgz",
-			"integrity": "sha512-Kb4xn5Qh1cxAKvQnzNWZ512DhABzyFNmsaJf3OAkWNa4NkaqWcNI8Tao8Tasi0/F4JD9oyG0YxuFyvyR57d+Gw==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.0.tgz",
+			"integrity": "sha512-xkRtOt3/3DzTKMOt3xahj2M/EqNhY988T+imYSlMgs5fVhLN2fmKVVj0LtEGmb+3UUYV5Qmm1052Mm3dIQxOvw==",
 			"dev": true,
 			"requires": {
 				"neo-async": "^2.6.0",


### PR DESCRIPTION
Updating one of the deep dependencies to fix `high severity vulnerability` warning raised during the `npm install`.