### PR TITLE
Increasing code coverage for `git` repo.

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -22,30 +22,31 @@ const HEAD_TAG = 'ref: refs/heads/';
  * GitRepo represents a Git Repository in the local filesystem.
  */
 export class GitRepo {
-   private readonly _gitPath : string;
-   /**
-    * Create a new instance of GitRepo which points to the git repository
-    * at the given path (the root where lives the `.git` folder).
-    * 
-    * @param pth the path of the git repository
-    */
-   constructor(pth: string) {
-      this._gitPath = path.join(pth, '.git');
-   }
+  private readonly _gitPath: string;
 
-   /**
-    * Return the current branch of the calling Git Repository.
-    * 
-    * @returns a Promises which resolves to the branch name's or send an 
-    * error if the path of this GitRepo doesn't points to an actual repository.
-    */
-   getCurrentBranch() : Promise<string> {
-      return new Promise((resolve, reject) => {
-         let headPath = path.join(this._gitPath, 'HEAD');
-         fs.readFile(headPath, "utf-8", (err, data) => {
-            if (err) { reject(err); } 
-            else { resolve(data.replace(HEAD_TAG, '').replace('\n', ''));}
-         });     
+  /**
+   * Create a new instance of GitRepo which points to the git repository
+   * at the given path (the root where lives the `.git` folder).
+   *
+   * @param pth the path of the git repository
+   */
+  constructor(pth: string) {
+    this._gitPath = path.join(pth, '.git');
+  }
+
+  /**
+   * Return the current branch of the calling Git Repository.
+   *
+   * @returns a Promises which resolves to the branch name's or send an
+   * error if the path of this GitRepo doesn't points to an actual repository.
+   */
+  getCurrentBranch(): Promise<string> {
+    return new Promise((resolve, reject) => {
+      let headPath = path.join(this._gitPath, 'HEAD');
+      fs.readFile(headPath, 'utf-8', (err, data) => {
+        if (err) { reject(err); }
+        else { resolve(data.replace(HEAD_TAG, '').replace('\n', ''));}
       });
-   }
+    });
+  }
 }

--- a/tests/git.test.ts
+++ b/tests/git.test.ts
@@ -1,0 +1,47 @@
+/*
+Copyright 2019 by Jakub Kaluzka
+   
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import createSpy = jasmine.createSpy;
+
+jest.mock('path');
+jest.mock('fs');
+import {GitRepo} from '../src/git';
+
+const fs = require('fs');
+
+describe('extension', () => {
+  let gitRepo: any;
+
+  beforeEach(() => {
+    gitRepo = new GitRepo('path_to_repository');
+    fs.readFile = jest.fn().mockImplementation((file, option, cb) => cb(null, 'ref: refs/heads/\nmaster'));
+  });
+
+  describe('getCurrentBranch', () => {
+    test('should return branch name', async () => {
+      // When
+      const branch = await gitRepo.getCurrentBranch();
+      // Then
+      expect(fs.readFile).toHaveBeenCalled();
+      expect(branch).toBe('master');
+    });
+
+    test('should reject Promise with an error', async () => {
+      // When
+      fs.readFile = jest.fn().mockImplementation((file, option, cb) => cb('error', 'ref: refs/heads/\nmaster'));
+      await expect(gitRepo.getCurrentBranch()).rejects.toEqual('error');
+    });
+  });
+});


### PR DESCRIPTION
Includes fixing formatting of `git.ts` file.

## Type of modification

* [ ] Breaking change
* [ ] New Feature
* [ ] Bug Fix
* [x] Chore (refactor, documentation, tests... all the changes with no impact 
on vscode-gcp-cloudbuild functionalities.) 

## Changes description

**Add some quick description about what your PullRequest change in
vscode-gcp-cloudbuild's feature/behavior**

Increasing code coverage for `git.ts`. Relates to #1 

## Technical description

**Add a quick description about what your PullRequest change in 
vscode-gcp-cloudbuild's code. (example: add a processor check in...)**

The new test file was created including tests implementations.

## PR CheckList

Please make sure your PullRequest respect all those items :

* [x] You have asked a review from one of the vscode-gcp-cloudbuild maintainer 
in your PR.
* [x] If your PR is related to an issue, add the issue's number in it.
* [x] All the code you added is documented.
* [x] All the code you added is tested and the  tests are in success.
